### PR TITLE
adding ssl verification & deletion of active support methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@
 -- v0.3.0 - adding HTTP proxy management and fixing circular reference
 
 -- v0.4.1 - adding random User-Agent generator
+
+-- v0.4.2 - adding ssl verification & deletion of active support methods

--- a/lib/tweakphoeus.rb
+++ b/lib/tweakphoeus.rb
@@ -18,21 +18,22 @@ module Tweakphoeus
       }
       @proxy = nil
       @proxyuserpwd = nil
+      @ssl_verifypeer = true
     end
 
-    def get(url, body: nil, params: nil, headers: nil, redirect: true)
+    def get(url, body: nil, params: nil, headers: nil, redirect: true, ssl_verifypeer: @ssl_verifypeer)
       set_referer_from_headers(headers)
-      http_request(url, body: body, params: params, headers: headers, redirect: redirect, method: :get)
+      http_request(url, body: body, params: params, headers: headers, redirect: redirect, method: :get, ssl_verifypeer: ssl_verifypeer)
     end
 
-    def delete(url, body: nil, headers: nil, redirect: true)
+    def delete(url, body: nil, headers: nil, redirect: true, ssl_verifypeer: @ssl_verifypeer)
       set_referer_from_headers(headers)
-      http_request(url, body: body, headers: headers, redirect: redirect, method: :delete)
+      http_request(url, body: body, headers: headers, redirect: redirect, method: :delete, ssl_verifypeer: ssl_verifypeer)
     end
 
-    def post(url, body: nil, params: nil, headers: nil, redirect: false)
+    def post(url, body: nil, params: nil, headers: nil, redirect: false, ssl_verifypeer: @ssl_verifypeer)
       set_referer_from_headers(headers)
-      http_request(url, body: body, params: nil, headers: headers, redirect: redirect, method: :post)
+      http_request(url, body: body, params: nil, headers: headers, redirect: redirect, method: :post, ssl_verifypeer: ssl_verifypeer)
     end
 
     def get_hide_inputs response
@@ -67,7 +68,7 @@ module Tweakphoeus
       headers ||= {}
       cookies = parse_cookie(headers["Cookie"])
 
-      while domain.present?
+      while domain != ""
         if @cookie_jar[domain]
           @cookie_jar[domain].each do |key, value|
             cookies[key] ||= value
@@ -91,11 +92,11 @@ module Tweakphoeus
 
     private
 
-    def http_request(url, body: nil, params: nil, headers: nil, redirect: false, method: :get)
+    def http_request(url, body: nil, params: nil, headers: nil, redirect: false, method: :get, ssl_verifypeer: @ssl_verifypeer)
       request_headers = merge_default_headers(headers)
       request_headers["Cookie"] = cookie_string(url, headers)
       request_headers["Referer"] = get_referer
-      response = Typhoeus.send(method, url, body: body, params: params, headers: request_headers, proxy: @proxy, proxyuserpwd: @proxyuserpwd)
+      response = Typhoeus.send(method, url, body: body, params: params, headers: request_headers, proxy: @proxy, proxyuserpwd: @proxyuserpwd, ssl_verifypeer: ssl_verifypeer)
       obtain_cookies(response)
       set_referer(url) if method != :post
       if redirect && has_redirect?(response)
@@ -107,7 +108,8 @@ module Tweakphoeus
                                 body: body,
                                 headers: headers,
                                 redirect: redirect,
-                                method: method)
+                                method: method,
+                                ssl_verifypeer: ssl_verifypeer)
       end
       response
     end

--- a/lib/tweakphoeus/user_agent.rb
+++ b/lib/tweakphoeus/user_agent.rb
@@ -10,7 +10,7 @@ module Tweakphoeus
     class << self
       def random(systems: OS_DATA[:types])
         user_agent = "Mozilla/5.0 (#{os[systems.sample]}) #{browser}"
-        firefox_version = user_agent.match(/Firefox\/([0-9\.]+)/).try(:[], 1)
+        firefox_version = user_agent.match(/Firefox\/([0-9\.]+)/)&.[](1)
         user_agent.gsub!(')', "; rv:#{firefox_version})") if firefox_version
         user_agent
       end

--- a/lib/tweakphoeus/version.rb
+++ b/lib/tweakphoeus/version.rb
@@ -1,3 +1,3 @@
 module Tweakphoeus
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
Some modification to let the gem support SSL verification option, allowing deactivating it in order to go on with some webs with certain required certifications.