### PR TITLE
Handling infinite redirection loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@
 -- v0.4.2 - adding ssl verification & deletion of active support methods
 
 -- v0.4.5 - pushing typhoeus version
+
+-- v0.4.6 - handling infinite redirection loop


### PR DESCRIPTION
Fixes infinite redirections to the same url. This could happen when we get a 302 HTTP code by response and the referrer never changes.

Typhoeus seems to have its own infinite loop redirection control but also seems to not be working at the moment: https://github.com/typhoeus/typhoeus/blob/181834e2483d392d0f7ab0cd17f544cd252c7b2f/lib/typhoeus/request.rb#L217