### PR TITLE
removing gemspec allowed_push_host entry

### DIFF
--- a/tweakphoeus.gemspec
+++ b/tweakphoeus.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.org/"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/dmartingarcia/Tweakphoeus"
   spec.metadata["changelog_uri"] = "https://github.com/dmartingarcia/Tweakphoeus/blob/master/CHANGELOG.md"


### PR DESCRIPTION
Because of an issue, while a Github action was trying to automatically push new versions of this gem to different repositories, It failed because of Gemspec's allowed_push_host config. 

That should be deleted