### PR TITLE
Adding missing requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,8 @@ Upgrading Typhoeus dependency to 1.4.0
   - ssl_verifypeer and redirect parameters removed from HTTP verb methods
   - cookie_jar is not longer an Hash, it has been extracted to Tweakphoeus::CookieJar class
   - refeer_list is not longer an Array, it has been extracted to Tweakphoeus::RefererList class
+
+-- v0.6.1 - Fixing issues with the modification of a frozen string
+  - Adds missing requires in the mail `.rb` file
+  - Solves an issue with a modification on a frozen string
+    > /Users/davidmartingarcia/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/tweakphoeus-0.6.0/lib/tweakphoeus/user_agent.rb:17:in `gsub!': can't modify frozen String: "Mozilla/5.0 (X11; gNewSense; Linux x86) Gecko/20100101 Firefox/84.0" (FrozenError)

--- a/lib/tweakphoeus.rb
+++ b/lib/tweakphoeus.rb
@@ -2,6 +2,8 @@
 
 require 'tweakphoeus/version'
 require 'tweakphoeus/user_agent'
+require 'tweakphoeus/cookie_jar'
+require 'tweakphoeus/referer_list'
 require 'typhoeus'
 
 module Tweakphoeus

--- a/lib/tweakphoeus/user_agent.rb
+++ b/lib/tweakphoeus/user_agent.rb
@@ -14,8 +14,7 @@ module Tweakphoeus
       def random(systems: OS_DATA[:types])
         user_agent = "Mozilla/5.0 (#{os[systems.sample]}) #{browser}"
         firefox_version = user_agent.match(%r{Firefox/([0-9.]+)})
-        user_agent.gsub!(')', "; rv:#{firefox_version[1]})") if firefox_version.is_a?(MatchData)
-        user_agent
+        user_agent.gsub(')', "; rv:#{firefox_version[1]})") if firefox_version.is_a?(MatchData)
       end
 
       private

--- a/lib/tweakphoeus/version.rb
+++ b/lib/tweakphoeus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tweakphoeus
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
What this PR does: 
- Adds missing requires in the mail `.rb` file
- Solves an issue with a modification on a frozen string 
  > /Users/davidmartingarcia/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/tweakphoeus-0.6.0/lib/tweakphoeus/user_agent.rb:17:in `gsub!': can't modify frozen String: "Mozilla/5.0 (X11; gNewSense; Linux x86) Gecko/20100101 Firefox/84.0" (FrozenError) 